### PR TITLE
Fix deprecation notice

### DIFF
--- a/export/entries.php
+++ b/export/entries.php
@@ -110,7 +110,7 @@ class cwp_gf_Entries_export_handler {
 	 * @param array ?$args = [] - If provided entries will be filtered
 	 *
 	 */
-	public static function excel_export( $args = [], $format ) {
+	public static function excel_export( $args = [], $format = 'xls' ) {
 		$args['post_type']      = self::post_type;
 		$args['posts_per_page'] = - 1; # for returning all posts
 


### PR DESCRIPTION
`Deprecated: Required parameter $format follows optional parameter $args in wp-content/plugins/forms-gutenberg/export/entries.php on line 121`